### PR TITLE
Fix duplicate inserted elements

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 		session.CheckCart()
 		for _, v := range session.Cart.FloorInfoList {
 			if v.FloorId == session.Conf.FloorId {
+				session.GoodsList = make([]dd.Goods, 0)
 				for index, goods := range v.NormalGoodsList {
 					session.GoodsList = append(session.GoodsList, goods.ToGoods())
 					fmt.Printf("[%v] %s 数量：%v 总价：%d\n", index, goods.GoodsName, goods.Quantity, goods.Price)


### PR DESCRIPTION
当服务端错误时， 重新执行CartLoop 的时候， GoodsList 数组重新插入元素