### PR TITLE
fix: missing promotion goods list

### DIFF
--- a/dd/cart.go
+++ b/dd/cart.go
@@ -40,6 +40,12 @@ func parseFloorInfos(g gjson.Result) (error, FloorInfo) {
 		_, p := parseNormalGoods(normalGoods)
 		r.NormalGoodsList = append(r.NormalGoodsList, p)
 	}
+	for _, promotionGoodsList := range g.Get("promotionFloorGoodsList").Array() {
+		for _, promotionGoods := range promotionGoodsList.Get("promotionGoodsList").Array() {
+			_, p := parseNormalGoods(promotionGoods)
+			r.NormalGoodsList = append(r.NormalGoodsList, p)
+		}
+	}
 
 	return nil, r
 }


### PR DESCRIPTION
如果购物车里有促销商品，脚本的购物车列表会丢失这些商品。抓包看数据如下：
"promotionFloorGoodsList":
                [
                    {
                        "title": "多买多省",
                        "promotionCode": "MERCHANT",
                        "promotionSubCode": "MJJ",
                        "promotionId": "1184758565593968749",
                        "tag": "满减",
                        "description": "已每满2件，已减65.00元",
                        "giveawayList": null,
                        "isReachThreshold": true,
                        "promotionGoodsList":
                        [
                            {
                                "storeId": "4865",
                                "storeType": 2,
                                "spuId": "23301996",
                                "skuId": null,
                                "brandId": "10207424",
                                ...
                            }
                        ],
                        "lastAddCartTime": "1649938841161"
                    }
                ],
